### PR TITLE
Add simple multi-app website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# TEST123
+# TEST123 Web Apps
 
-This repository contains a simple JavaScript web page demonstrating a basic widget.
+This repository now contains a small collection of simple web apps.
 
-## Getting Started
+## Available Apps
+- **Counter App** (`counter.html`)
+- **Calculator App** (`calculator.html`)
+- **Todo App** (`todo.html`)
 
-Open `index.html` in your web browser to view the page.
-
-Click the **Increment** button to see the counter widget update.
+Open `index.html` to access the list of apps.

--- a/calculator.html
+++ b/calculator.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Calculator App</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Calculator App</h1>
+    <nav>
+        <a href="index.html">Home</a>
+    </nav>
+    <div id="calculator">
+        <input type="text" id="calc-display" readonly>
+        <div id="calc-buttons">
+            <button class="digit">7</button>
+            <button class="digit">8</button>
+            <button class="digit">9</button>
+            <button class="op">/</button>
+            <button class="digit">4</button>
+            <button class="digit">5</button>
+            <button class="digit">6</button>
+            <button class="op">*</button>
+            <button class="digit">1</button>
+            <button class="digit">2</button>
+            <button class="digit">3</button>
+            <button class="op">-</button>
+            <button class="digit">0</button>
+            <button id="calc-clear">C</button>
+            <button id="calc-equals">=</button>
+            <button class="op">+</button>
+        </div>
+    </div>
+    <script src="calculator.js"></script>
+</body>
+</html>

--- a/calculator.js
+++ b/calculator.js
@@ -1,0 +1,25 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const display = document.getElementById('calc-display');
+    const buttons = document.getElementById('calc-buttons');
+    let current = '';
+
+    buttons.addEventListener('click', (e) => {
+        const target = e.target;
+        if (target.tagName !== 'BUTTON') return;
+
+        if (target.classList.contains('digit')) {
+            current += target.textContent;
+        } else if (target.classList.contains('op')) {
+            current += ` ${target.textContent} `;
+        } else if (target.id === 'calc-clear') {
+            current = '';
+        } else if (target.id === 'calc-equals') {
+            try {
+                current = eval(current).toString();
+            } catch {
+                current = 'Error';
+            }
+        }
+        display.value = current;
+    });
+});

--- a/counter.html
+++ b/counter.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Simple Widget App</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Simple Widget App</h1>
+    <nav><a href="index.html">Home</a></nav>
+    <div id="widget">
+        <p>Counter: <span id="count">0</span></p>
+        <button id="increment">Increment</button>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -2,15 +2,18 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Simple Widget App</title>
+    <title>My Web Apps</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <h1>Simple Widget App</h1>
-    <div id="widget">
-        <p>Counter: <span id="count">0</span></p>
-        <button id="increment">Increment</button>
-    </div>
-    <script src="script.js"></script>
+    <h1>Welcome to My Web Apps</h1>
+    <nav>
+        <ul>
+            <li><a href="counter.html">Counter App</a></li>
+            <li><a href="calculator.html">Calculator App</a></li>
+            <li><a href="todo.html">Todo App</a></li>
+        </ul>
+    </nav>
+    <p>Select an app from the list above to get started.</p>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -13,3 +13,37 @@ body {
 button {
     padding: 5px 10px;
 }
+nav ul {
+    list-style: none;
+    padding: 0;
+}
+
+nav li {
+    display: inline-block;
+    margin-right: 10px;
+}
+
+#calculator {
+    width: 200px;
+    margin-top: 20px;
+}
+
+#calc-display {
+    width: 100%;
+    margin-bottom: 10px;
+}
+
+#calc-buttons button {
+    width: 45px;
+    height: 45px;
+    margin: 2px;
+}
+
+#todo-container {
+    margin-top: 20px;
+    width: 300px;
+}
+
+#todo-list li {
+    margin-bottom: 5px;
+}

--- a/todo.html
+++ b/todo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Todo App</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Todo App</h1>
+    <nav>
+        <a href="index.html">Home</a>
+    </nav>
+    <div id="todo-container">
+        <input type="text" id="todo-input" placeholder="New task">
+        <button id="todo-add">Add</button>
+        <ul id="todo-list"></ul>
+    </div>
+    <script src="todo.js"></script>
+</body>
+</html>

--- a/todo.js
+++ b/todo.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const input = document.getElementById('todo-input');
+    const addBtn = document.getElementById('todo-add');
+    const list = document.getElementById('todo-list');
+
+    addBtn.addEventListener('click', () => {
+        const text = input.value.trim();
+        if (!text) return;
+        const li = document.createElement('li');
+        li.textContent = text;
+        const del = document.createElement('button');
+        del.textContent = 'Remove';
+        del.addEventListener('click', () => li.remove());
+        li.appendChild(del);
+        list.appendChild(li);
+        input.value = '';
+    });
+});


### PR DESCRIPTION
## Summary
- overhaul README to describe multiple apps
- create a home page with navigation links
- split old counter widget into `counter.html`
- add Calculator and Todo apps with JS logic
- expand CSS styling for navigation and new apps

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6841b7ae86888322aecdb4973f332126