### PR TITLE
Add workflow to deploy site to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy static site to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/configure-pages@v3
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: .
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -8,3 +8,13 @@ This repository now contains a small collection of simple web apps.
 - **Todo App** (`todo.html`)
 
 Open `index.html` to access the list of apps.
+
+## Hosting Online via GitHub Pages
+
+The repository includes a GitHub Actions workflow that publishes the site to **GitHub Pages** whenever changes are pushed to the `main` branch. To enable this:
+
+1. Open your repository on GitHub and navigate to **Settings \> Pages**.
+2. Select **GitHub Actions** as the source and save.
+3. Push any changes to `main` to trigger the workflow.
+
+After deployment completes, your apps will be accessible at `https://<username>.github.io/<repository>/`.


### PR DESCRIPTION
## Summary
- add GitHub Pages deployment workflow
- document how to host the site using GitHub Pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842162b1fd48322a741ae5ae507be88